### PR TITLE
Implement URI parsing and a URI representation class.

### DIFF
--- a/kachery_client/__init__.py
+++ b/kachery_client/__init__.py
@@ -4,6 +4,7 @@ from .main import create_feed
 from .main import store_file, store_json, store_npy, store_pkl, store_text, link_file
 from .main import get, set, get_feed_id, get_string
 from .main import watch_for_new_messages
+from .main import parse_uri, build_uri
 
 from .request_task import request_task
 from .task_backend.taskfunction import taskfunction

--- a/kachery_client/_uri_handling.py
+++ b/kachery_client/_uri_handling.py
@@ -1,0 +1,46 @@
+class KacheryUri:
+    algorithm: str = ''
+    hash: str = ''
+    filename: str = ''
+
+    def __init__(self, *, algorithm: str, hash: str, filename: str):
+        assert algorithm in ['SHA1', 'sha1'], "Unrecognized algorithm."
+        # TODO: Do we have criteria for hashes?
+        self.algorithm = algorithm
+        self.hash = hash
+        self.filename = filename
+
+    def emit_uri(self) -> str:
+        return f"{self.algorithm}://{self.hash}/{self.filename}"
+
+    def __str__(self):
+        return self.emit_uri()
+    
+    def __repr__(self):
+        return f"""
+algorithm:\t{self.algorithm}
+hash:\t\t{self.hash}
+filename:\t{self.filename}"""
+
+def _build_uri(*, uri_object: KacheryUri) -> str:
+    return uri_object.emit_uri()
+
+def _parse_uri(*, uri: str) -> KacheryUri:
+    # Expected URI format:
+    # [ALGORITHM]://[HASH]/[FILENAME]
+    parsed = uri.split('/')
+    if (len(parsed) < 3):
+        raise Exception(f"Cannot parse malformed URI {uri}.")
+    
+    # remove the trailing : from the algorithm field
+    parsed[0] = parsed[0].rstrip(':')
+
+    # handle case where the filename is not set
+    if len(parsed) == 3:
+        parsed.append('')
+
+    return KacheryUri(
+        algorithm=parsed[0].lower(),
+        hash=parsed[2],
+        filename=parsed[3]
+    )

--- a/kachery_client/main.py
+++ b/kachery_client/main.py
@@ -9,6 +9,7 @@ from ._mutables import (_get, _set, _delete)
 from ._load_file import _load_file, _load_bytes, _load_text, _load_json, _load_npy, _load_pkl
 from ._store_file import _store_file, _store_text, _store_json, _store_npy, _store_pkl, _link_file
 from ._daemon_connection import _get_node_id
+from ._uri_handling import KacheryUri, _build_uri, _parse_uri
 
 def load_file(
     uri: str,
@@ -281,3 +282,28 @@ def delete(key: Union[str, dict, list], value: Union[str, dict, list]):
         None
     """
     return _delete(key=key)
+
+################################################
+
+def parse_uri(uri: str):
+    """Convert a URI into an instance of a class with semantically meaningful
+    members.
+
+    Args:
+        uri (str): URI to parse.
+
+    Returns:
+        KacheryUri: A meaningfully parsed representation of the URI.
+    """
+    return _parse_uri(uri=uri)
+
+def build_uri(uri_object: KacheryUri):
+    """Returns a string URI from the named component elements.
+
+    Args:
+        uri_object (KacheryUri): Object representation of the URI.
+
+    Returns:
+        str: A usable URI string.
+    """    
+    return _build_uri(uri_object=uri_object)


### PR DESCRIPTION
Intended to address an improvement request from Sortingview issue #96 (https://github.com/magland/sortingview/issues/96).

This PR implements a simple Python class to parse kachery URIs of the form "[algorithm]://[hash]/[filename]", with the [filename] component optional. Algorithms are validated to the supported set (currently just sha1).

Also included are static methods to parse an existing URI string and to emit a well-formed URI from the data class.