### PR TITLE
Add environment variables for kacheryhub, bitwooder API endpoints.

### DIFF
--- a/kachery_client/_misc.py
+++ b/kachery_client/_misc.py
@@ -27,7 +27,6 @@ def _get_envvar_uri(environment_var_name: str, default: str) -> Tuple[str, str]:
 
 def _get_kachery_hub_uri(with_protocol=True) -> str:
     (protocol, uri) = _get_envvar_uri('KACHERY_HUB_API_URI', 'kacheryhub.org')
-    print(f'DEBUG: returning kachery-hub uri {protocol}://{uri}')
     if (with_protocol):
         return f'{protocol}://{uri}'
     return uri

--- a/kachery_client/_misc.py
+++ b/kachery_client/_misc.py
@@ -1,8 +1,42 @@
 import os
+import re
 import time
 import json
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 from urllib.parse import parse_qs
+
+def _parse_string_to_protocol_and_basename(string: str) -> Union[Tuple[str, str], None]:
+    expr = re.compile('^(https?://)?(.*?)/?$')
+    match = expr.match(string)
+    if (not match):
+        return None
+    protocol = match.group(1) or 'https'
+    if (protocol[-3:] == '://'):
+        protocol = protocol[:-3]
+    uri = match.group(2)
+    if (':' in uri or '/' in uri):
+        return None
+    return (protocol, uri)
+
+def _get_envvar_uri(environment_var_name: str, default: str) -> Tuple[str, str]:
+    endpoint = os.getenv(environment_var_name, default)
+    res = _parse_string_to_protocol_and_basename(endpoint)
+    if (not res):
+        raise Exception(f'Error: invalid value for environment variable {environment_var_name} ({endpoint})')
+    return res
+
+def _get_kachery_hub_uri(with_protocol=True) -> str:
+    (protocol, uri) = _get_envvar_uri('KACHERY_HUB_API_URI', 'kacheryhub.org')
+    print(f'DEBUG: returning kachery-hub uri {protocol}://{uri}')
+    if (with_protocol):
+        return f'{protocol}://{uri}'
+    return uri
+
+def _get_bitwooder_uri(with_protocol=True) -> str:
+    (protocol, uri) = _get_envvar_uri('BITWOODER_API_URI', 'bitwooder.net')
+    if (with_protocol):
+        return f'{protocol}://{uri}'
+    return uri
 
 def _parse_kachery_uri(uri: str) -> Tuple[str, str, str, str, dict]:
     listA = uri.split('?')

--- a/kachery_client/direct_client/DirectClient.py
+++ b/kachery_client/direct_client/DirectClient.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from typing import Union, Any, List
 import numpy as np
-from .._misc import _http_post_json, _parse_kachery_uri
+from .._misc import _http_post_json, _parse_kachery_uri, _get_kachery_hub_uri
 from .._temporarydirectory import TemporaryDirectory
 from ..main import store_file, load_file, store_npy, store_pkl, store_text, store_json
 from .._daemon_connection import _probe_daemon
@@ -13,9 +13,10 @@ from .._safe_pickle import _safe_unpickle, _safe_pickle
 _bucket_base_urls = {} # by channel
 
 def _get_bucket_base_url(channel: str):
+    endpoint = _get_kachery_hub_uri(with_protocol=True)
     if channel in _bucket_base_urls:
         return _bucket_base_urls[channel]
-    response = _http_post_json('https://kacheryhub.org/api/getChannelBucketBaseUrl', {'channelName': channel})
+    response = _http_post_json(f'{endpoint}/api/getChannelBucketBaseUrl', {'channelName': channel})
     url = response['url']
     _bucket_base_urls[channel] = url
     return url

--- a/kachery_client/ephemeral/ephemeral_load_file.py
+++ b/kachery_client/ephemeral/ephemeral_load_file.py
@@ -4,7 +4,7 @@ from typing import Union, Any
 import shutil
 import numpy as np
 from ..direct_client.DirectClient import _get_ephemeral_kachery_storage_dir
-from .._misc import _http_post_json, _parse_kachery_uri
+from .._misc import _http_post_json, _parse_kachery_uri, _get_kachery_hub_uri
 from .._temporarydirectory import TemporaryDirectory
 from ..direct_client.DirectClient import _concatenate_file_chunks, _http_get_file
 from .._local_kachery_storage import _compute_file_hash
@@ -75,7 +75,8 @@ def _get_node_config():
         'nodeId': public_key_hex,
         'signature': signature
     }
-    url = f'https://kacheryhub.org/api/kacheryNode'
+    endpoint = _get_kachery_hub_uri(with_protocol=True)
+    url = f'{endpoint}/api/kacheryNode'
     resp = _http_post_json(url, req)
     if not resp['found']:
         raise Exception('Node not found on kacheryhub')

--- a/kachery_client/ephemeral/ephemeral_upload_file.py
+++ b/kachery_client/ephemeral/ephemeral_upload_file.py
@@ -1,6 +1,6 @@
 import time
 from .ephemeral_load_file import _get_private_key_hex, _get_public_key_hex, _get_owner, _sign_message
-from .._misc import _http_post_json
+from .._misc import _http_post_json, _get_kachery_hub_uri, _get_bitwooder_uri
 from ..task_backend._update_task_status import _http_put_bytes
 
 
@@ -26,7 +26,8 @@ def _get_channel_config(channel: str):
         'nodeId': public_key_hex,
         'signature': signature
     }
-    url = f'https://kacheryhub.org/api/kacheryNode'
+    endpoint_uri = _get_kachery_hub_uri(with_protocol=True)
+    url = f'{endpoint_uri}/api/kacheryNode'
     resp = _http_post_json(url, req)
     if not resp['found']:
         raise Exception('Channel config not found')
@@ -55,7 +56,8 @@ def _get_bitwooder_cert_for_channel(channel: str):
         'nodeId': public_key_hex,
         'signature': signature
     }
-    url = f'https://kacheryhub.org/api/kacheryNode'
+    endpoint_uri = _get_kachery_hub_uri(with_protocol=True)
+    url = f'{endpoint_uri}/api/kacheryNode'
     resp = _http_post_json(url, req)
     cert = resp['cert']
     key = resp['key']
@@ -90,7 +92,8 @@ def ephemeral_upload_file(*, file_content: bytes, sha1: str, channel: str) -> No
             'delegationCertificate': cert
         }
     }
-    url = f'https://bitwooder.net/api/resource'
+    endpoint = _get_bitwooder_uri(with_protocol=True)
+    url = f'{endpoint}/api/resource'
     resp = _http_post_json(url, req)
     upload_urls = resp['uploadUrls']
     upload_url = upload_urls[0]

--- a/kachery_client/ephemeral_client_deprecated/EphemeralClient.py
+++ b/kachery_client/ephemeral_client_deprecated/EphemeralClient.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from typing import Union, Any, List
 import numpy as np
-from .._misc import _http_post_json, _parse_kachery_uri
+from .._misc import _http_post_json, _parse_kachery_uri, _get_kachery_hub_uri
 from .._temporarydirectory import TemporaryDirectory
 from ..main import store_file, load_file, store_npy, store_pkl, store_text, store_json
 from .._daemon_connection import _probe_daemon
@@ -15,7 +15,8 @@ _bucket_base_urls = {} # by channel
 def _get_bucket_base_url(channel: str):
     if channel in _bucket_base_urls:
         return _bucket_base_urls[channel]
-    response = _http_post_json('https://kacheryhub.org/api/getChannelBucketBaseUrl', {'channelName': channel})
+    endpoint_uri = _get_kachery_hub_uri(with_protocol=True)
+    response = _http_post_json(f'{endpoint_uri}/api/getChannelBucketBaseUrl', {'channelName': channel})
     url = response['url']
     _bucket_base_urls[channel] = url
     return url

--- a/kachery_client/setup_colab_ephemeral.py
+++ b/kachery_client/setup_colab_ephemeral.py
@@ -1,6 +1,7 @@
 import os
 import json
 import kachery_client as kc
+from ._misc import _get_kachery_hub_uri
 from .ephemeral.ephemeral_load_file import _get_public_key_hex, _get_private_key_hex, _get_owner, _get_ephemeral_kachery_storage_dir, _public_key_from_hex, _private_key_from_hex, _public_key_to_hex, _private_key_to_hex
 
 def setup_colab_ephemeral(config_file_path: str):
@@ -55,6 +56,7 @@ def setup_colab_ephemeral(config_file_path: str):
   print(f'Enabling ephemeral mode')
   kc.enable_ephemeral()
 
+  endpoint = _get_kachery_hub_uri(with_protocol=True)
   print(f'Node ID: {node_id}')
   print(f'Owner: {owner_id}')
-  print(f'Register or configure this node at https://kacheryhub.org')
+  print(f'Register or configure this node at {endpoint}')


### PR DESCRIPTION
Acceptable values are reasonably tolerant; if http or https is given as a protocol, this will be accepted and honored (will default to https). Variables `KACHERY_HUB_API_URI` and `BITWOODER_API_URI` otherwise expect a fully qualified domain name (e.g. `dev.kacheryhub.org`) but will accept & remove trailing slashes. I set up the parser to reject anything that has an internal slash or colon, since these are probably signs of a malformed protocol specification and/or trying to point to something more specific than the FQDN; this can be relaxed if we need to support that case in the future.